### PR TITLE
Update commit types and scopes conventions

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,43 +2,44 @@ export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'type-enum': [2, 'always', [
-      'feat',
-      'fix',
-      'docs',
-      'style',
-      'refactor',
-      'perf',
-      'test',
-      'build',
-      'ci',
-      'chore',
-      'revert',
-      'security'
+      // Types (HOW the change is made)
+      'feat',     // New feature
+      'fix',      // Bug fix
+      'docs',    // Documentation only
+      'style',   // Formatting, typos, etc
+      'refactor',// Code change that neither fixes a bug nor adds a feature
+      'perf',   // Performance improvement
+      'test',   // Adding missing tests
+      'build',   // Changes that affect the build system or external dependencies
+      'ci',   // Changes to CI configuration files and scripts
+      'chore',   // Other changes that don't modify src or test files
+      'revert',  // Reverts a previous commit
+      'security', // Security improvements
     ]],
     'scope-enum': [2, 'always', [
+      // Scopes (WHAT is being changed)
       // Core
-      'core',
-      'deps',
-      'config',
+      'core',    // Core application logic
+      'deps',   // Dependencies
+      'config', // Configuration files
 
       // Security & Auth
-      'security',  // Added back
-      'auth',
+      'auth',   // Authentication/Authorization
 
       // Application Layers
-      'api',
-      'ui',
-      'db',
+      'api',  // API related changes
+      'ui',   // User interface
+      'db',   // Database
 
       // Infrastructure
-      'ci',
-      'build',
+      'infra',  // Infrastructure related changes
+      'deploy', // Deployment specific changes
 
       // Documentation
-      'docs',
+      'docs',  // Documentation
 
       // Testing
-      'test'
+      'test',    // Test infrastructure
     ]],
     'scope-case': [2, 'always', 'lowercase'],
     'scope-empty': [2, 'never'],


### PR DESCRIPTION
Closes #11 

# Update Commit Conventions

This PR updates our commit types and scopes to provide clearer boundaries and avoid overlapping categories.

## Changes Made

### Removed Scopes
- `ci` (overlaps with ci type)
- `build` (consolidated into infra)
- `security` (overlaps with security type)

### Added Scopes
- `infra`: For infrastructure related changes
- `deploy`: For deployment specific changes

## New Convention Structure

### Types (HOW the change is made)
```javascript
'feat'     // New feature
'fix'      // Bug fix
'docs'     // Documentation only
'style'    // Formatting, typos, etc
'refactor' // Code change that neither fixes a bug nor adds a feature
'perf'     // Performance improvement
'test'     // Adding missing tests
'build'    // Changes that affect the build system or external dependencies
'ci'       // Changes to CI configuration files and scripts
'chore'    // Other changes that don't modify src or test files
'revert'   // Reverts a previous commit
'security' // Security improvements
```

### Scopes (WHAT is being changed)
```javascript
// Core
'core'    // Core application logic
'deps'    // Dependencies
'config'  // Configuration files

// Security & Auth
'auth'    // Authentication/Authorization

// Application Layers
'api'     // API related changes
'ui'      // User interface
'db'      // Database

// Infrastructure
'infra'   // Infrastructure related changes
'deploy'  // Deployment specific changes

// Documentation
'docs'    // Documentation

// Testing
'test'    // Test infrastructure
```
