### PR TITLE
[Refactor] Move Ticket Grouping Logic from Views to Dedicated Action with Configuration Support

### DIFF
--- a/app/Actions/Ticket/GroupTicketsAction.php
+++ b/app/Actions/Ticket/GroupTicketsAction.php
@@ -1,0 +1,110 @@
+<?php
+    declare( strict_types = 1 );
+
+    namespace App\Actions\Ticket;
+
+    use App\Models\User;
+    use Illuminate\Support\Collection;
+    use InvalidArgumentException;
+    use Throwable;
+
+    class GroupTicketsAction
+    {
+        /**
+         * Group tickets based on provided configuration
+         *
+         * @param  Collection  $tickets  The collection of tickets to group
+         * @param  array  $groupConfigs  Array of group configurations
+         * @param  User|null  $user  The current user (optional)
+         * @return array Grouped tickets with titles and messages
+         * @throws InvalidArgumentException When group configuration is invalid
+         */
+        public function execute( Collection $tickets, array $groupConfigs, ?User $user = null ) : array
+        {
+            $ticketGroups = [];
+
+            try {
+                if ( $tickets->isEmpty() ) {
+                    $ticketGroups = $this->getEmptyGroups( $groupConfigs );
+                } else {
+                    $ticketGroups = array_map(
+                        fn( array $config ) : array => [
+                            'title' => $config['title'],
+                            'tickets' => $this->filterTickets( $tickets, $config, $user ),
+                            'no_tickets_msg' => $config['no_tickets_msg']
+                        ],
+                        $groupConfigs
+                    );
+                }
+            } catch (Throwable $e) {
+                report( $e );
+                $ticketGroups = $this->getFallbackGroups( $tickets );
+            }
+            return $ticketGroups;
+        }
+
+        /**
+         * Filter tickets based on configuration
+         *
+         * @param  Collection  $tickets
+         * @param  array  $config
+         * @param  User|null  $user
+         * @return Collection
+         */
+        private function filterTickets( Collection $tickets, array $config, ?User $user ) : Collection
+        {
+            try {
+                return $tickets->filter( function ( $ticket ) use ( $config, $user ) {
+                    $statusMatch = \in_array( $ticket->status, $config['status'], true );
+
+                    if ( !$statusMatch ) {
+                        return false;
+                    }
+
+                    if ( isset( $config['assignee_required'] ) && $config['assignee_required'] ) {
+                        return $user && $ticket->assignee_id === $user->id;
+                    }
+
+                    return true;
+                } );
+            } catch (Throwable $e) {
+                report( $e );
+                return collect();
+            }
+        }
+
+        /**
+         * Generate empty groups from configuration
+         *
+         * @param  array  $groupConfigs
+         * @return array
+         */
+        private function getEmptyGroups( array $groupConfigs ) : array
+        {
+            return array_map(
+                fn( array $config ) : array => [
+                    'title' => $config['title'],
+                    'tickets' => collect(),
+                    'no_tickets_msg' => $config['no_tickets_msg']
+                ],
+                $groupConfigs
+            );
+        }
+
+        /**
+         * Generate fallback groups in case of error
+         *
+         * @param  Collection  $tickets
+         * @return array
+         */
+        private function getFallbackGroups( Collection $tickets ) : array
+        {
+            return [
+                [
+                    'title' => 'All Tickets',
+                    'tickets' => $tickets,
+                    'no_tickets_msg' => 'No tickets available'
+                ]
+            ];
+        }
+    }

--- a/app/Config/TicketGroupings.php
+++ b/app/Config/TicketGroupings.php
@@ -1,0 +1,40 @@
+<?php
+    declare( strict_types = 1 );
+
+    namespace App\Config;
+
+    use App\Validators\TicketGroupingsValidator;
+    use Illuminate\Support\Facades\Config;
+
+    /**
+     * Class TicketGroupings
+     * Provides an abstraction layer for accessing ticket grouping configurations.
+     */
+    class TicketGroupings
+    {
+        /**
+         * Get index page grouping configuration
+         *
+         * @return array
+         */
+        public static function getIndexGroupings() : array
+        {
+            $groupings = Config::get( 'tickets.groupings.index', [] );
+            TicketGroupingsValidator::validate( $groupings );
+
+            return $groupings;
+        }
+
+        /**
+         * Get my tickets page grouping configuration
+         *
+         * @return array
+         */
+        public static function getMyTicketsGroupings() : array
+        {
+            $groupings = Config::get( 'tickets.groupings.my_tickets', [] );
+            TicketGroupingsValidator::validate( $groupings );
+
+            return $groupings;
+        }
+    }

--- a/app/Config/TicketGroupings.php
+++ b/app/Config/TicketGroupings.php
@@ -19,7 +19,7 @@
          */
         public static function getIndexGroupings() : array
         {
-            $groupings = Config::get( 'tickets.groupings.index', [] );
+            $groupings = Config::get( 'tickets.groupings.index' );
             TicketGroupingsValidator::validate( $groupings );
 
             return $groupings;
@@ -32,7 +32,7 @@
          */
         public static function getMyTicketsGroupings() : array
         {
-            $groupings = Config::get( 'tickets.groupings.my_tickets', [] );
+            $groupings = Config::get( 'tickets.groupings.my_tickets' );
             TicketGroupingsValidator::validate( $groupings );
 
             return $groupings;

--- a/app/Validators/TicketGroupingsValidator.php
+++ b/app/Validators/TicketGroupingsValidator.php
@@ -1,0 +1,26 @@
+<?php
+    declare( strict_types = 1 );
+
+    namespace App\Validators;
+
+    use Illuminate\Support\Facades\Validator;
+
+    class TicketGroupingsValidator
+    {
+        public static function validate( array $groupings ) : void
+        {
+            foreach ( $groupings as $group ) {
+                $validator = Validator::make( $group, [
+                    'title' => 'required|string',
+                    'status' => 'required|array',
+                    'status.*' => 'string',
+                    'assignee_required' => 'sometimes|boolean',
+                    'no_tickets_msg' => 'required|string',
+                ] );
+
+                if ( $validator->fails() ) {
+                    throw new \RuntimeException( 'Invalid ticket group configuration: ' . $validator->errors()->first() );
+                }
+            }
+        }
+    }

--- a/app/Validators/TicketGroupingsValidator.php
+++ b/app/Validators/TicketGroupingsValidator.php
@@ -4,12 +4,27 @@
     namespace App\Validators;
 
     use Illuminate\Support\Facades\Validator;
+    use RuntimeException;
 
     class TicketGroupingsValidator
     {
-        public static function validate( array $groupings ) : void
+        public static function validate( ?array $groupings ) : void
         {
-            foreach ( $groupings as $group ) {
+            if ( !\is_array( $groupings ) ) {
+                throw new RuntimeException( 'Ticket groupings configuration must be a valid array' );
+            }
+
+            if ( empty( $groupings ) ) {
+                throw new RuntimeException( 'Ticket groupings configuration cannot be empty' );
+            }
+
+            foreach ( $groupings as $index => $group ) {
+                if ( !\is_array( $group ) ) {
+                    throw new RuntimeException(
+                        "Invalid ticket group configuration: Group at index {$index} must be an array"
+                    );
+                }
+
                 $validator = Validator::make( $group, [
                     'title' => 'required|string',
                     'status' => 'required|array',
@@ -19,7 +34,9 @@
                 ] );
 
                 if ( $validator->fails() ) {
-                    throw new \RuntimeException( 'Invalid ticket group configuration: ' . $validator->errors()->first() );
+                    throw new RuntimeException(
+                        'Invalid ticket group configuration: ' . $validator->errors()->first()
+                    );
                 }
             }
         }

--- a/config/tickets.php
+++ b/config/tickets.php
@@ -1,0 +1,50 @@
+<?php
+    declare( strict_types = 1 );
+
+    return [
+        'groupings' => [
+            'index' => [
+                [
+                    'title' => 'Working On It',
+                    'status' => [ 'in-progress', 'awaiting-acceptance' ],
+                    'assignee_required' => true,
+                    'no_tickets_msg' => 'You Are Not Currently Working on Any Tickets'
+                ],
+                [
+                    'title' => 'Un-Assigned Tickets',
+                    'status' => [ 'open' ],
+                    'assignee_required' => false,
+                    'no_tickets_msg' => 'There are No Un-Assigned Tickets'
+                ],
+                [
+                    'title' => 'Resolved It',
+                    'status' => [ 'resolved' ],
+                    'assignee_required' => true,
+                    'no_tickets_msg' => 'You did NOT Resolve Any Tickets Yet'
+                ],
+                [
+                    'title' => 'Resolved',
+                    'status' => [ 'resolved' ],
+                    'assignee_required' => false,
+                    'no_tickets_msg' => 'There are No Resolved Tickets'
+                ]
+            ],
+            'my_tickets' => [
+                [
+                    'title' => 'Pending Action',
+                    'status' => [ 'awaiting-acceptance' ],
+                    'no_tickets_msg' => 'no tickets are pending action from you'
+                ],
+                [
+                    'title' => 'On-Going',
+                    'status' => [ 'open', 'in-progress', 'elevated' ],
+                    'no_tickets_msg' => 'you do not have ongoing tickets'
+                ],
+                [
+                    'title' => 'Resolved',
+                    'status' => [ 'resolved' ],
+                    'no_tickets_msg' => 'you do not have any closed tickets yet'
+                ]
+            ]
+        ]
+    ];

--- a/database/factories/TicketFactory.php
+++ b/database/factories/TicketFactory.php
@@ -1,26 +1,14 @@
 <?php
-    declare( strict_types = 1 );
 
     namespace Database\Factories;
 
-    use App\Models\Ticket;
     use App\Models\User;
+    use Carbon\Carbon;
     use Illuminate\Database\Eloquent\Factories\Factory;
     use Illuminate\Support\Arr;
-    use Illuminate\Support\Carbon;
 
-    /**
-     * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Ticket>
-     */
     class TicketFactory extends Factory
     {
-        protected $model = Ticket::class;
-
-        /**
-         * Define the model's default state.
-         *
-         * @return array<string, mixed>
-         */
         public function definition() : array
         {
             return [
@@ -29,12 +17,71 @@
                 'status' => Arr::random( array_keys( config( 'enums.ticket_status' ) ) ),
                 'priority' => Arr::random( array_keys( config( 'enums.ticket_priority' ) ) ),
                 'timeout_at' => $this->faker->dateTimeBetween( '-2 hours', '+2 hours' ),
-                'requestor_id' => User::isEmployee()->inRandomOrder()->first()->id,
-                'assignee_id' => User::isAgent()->inRandomOrder()->first()->id,
+                'requestor_id' => null,  // Optional by default
+                'assignee_id' => null,   // Optional by default
                 'meeting_room' => $this->faker->optional()->word(),
                 'created_at' => Carbon::now(),
                 'updated_at' => Carbon::now(),
             ];
         }
 
+        /**
+         * Set the requestor for the ticket
+         */
+        public function withRequestor( ?User $user = null ) : self
+        {
+            return $this->state( fn( array $attributes ) => [
+                'requestor_id' => $user?->id ??
+                    User::factory()->state( [ 'role' => 'employee' ] )->create()->id
+            ] );
+        }
+
+        /**
+         * Set the assignee for the ticket
+         */
+        public function withAssignee( ?User $user = null ) : self
+        {
+            return $this->state( fn( array $attributes ) => [
+                'assignee_id' => $user?->id ??
+                    User::factory()->state( [ 'role' => 'agent' ] )->create()->id
+            ] );
+        }
+
+        /**
+         * Set ticket status to in-progress
+         */
+        public function inProgress() : self
+        {
+            return $this->state( [
+                'status' => 'in-progress'
+            ] );
+        }
+
+        /**
+         * Set ticket status to open
+         */
+        public function open() : self
+        {
+            return $this->state( [
+                'status' => 'open'
+            ] );
+        }
+
+        /**
+         * Set ticket status to resolved
+         */
+        public function resolved() : self
+        {
+            return $this->state( [
+                'status' => 'resolved'
+            ] );
+        }
+
+        /**
+         * Create a ticket with all required relationships
+         */
+        public function complete() : self
+        {
+            return $this->withRequestor()->withAssignee();
+        }
     }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,5 +29,6 @@
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
+        <env name="CI" value="true"/>
     </php>
 </phpunit>

--- a/resources/views/tickets/index.blade.php
+++ b/resources/views/tickets/index.blade.php
@@ -1,34 +1,3 @@
-@php
-    use App\Models\Ticket;
-
-        $ticketGroups = [
-                    [
-                        'title' => 'Working On It',
-                        'tickets' => $tickets->filter( fn( $ticket ) =>
-                            $ticket->assignee_id === auth()->id() &&
-                            in_array($ticket->status, ['in-progress', 'awaiting-acceptance'])
-                          ),
-                        'no_tickets_msg' => 'You Are Not Currently Working on Any Tickets',
-                    ],
-                    [
-                        'title' => 'Un-Assigned Tickets',
-                        'tickets' => $tickets->filter( fn( $ticket ) => $ticket->status === 'open'),
-                        'no_tickets_msg' => 'There are No Un-Assigned Tickets',
-                    ],
-                    [
-                        'title' => 'Resolved It',
-                        'tickets' => $tickets->filter( fn( $ticket ) =>
-                                        $ticket->status === 'resolved' &&
-                                        $ticket->assignee_id === auth()->id() ),
-                        'no_tickets_msg' => 'You did NOT Resolve Any Tickets Yet',
-                    ],
-                    [
-                        'title' => 'Resolved',
-                        'tickets' => $tickets->filter( fn( $ticket ) => $ticket->status === 'resolved' ),
-                        'no_tickets_msg' => 'There are No Resolved Tickets',
-                    ]
-                ]
-@endphp
 @extends('components.layout.app')
 @section('content')
     <div class="mb-6 flex justify-end">
@@ -47,4 +16,5 @@
                                          :no_tickets_msg="$group['no_tickets_msg']">
         </x-tickets.index.section.content>
     @endforeach
+    {{ $tickets->links() }}
 @endsection

--- a/resources/views/tickets/my-tickets.blade.php
+++ b/resources/views/tickets/my-tickets.blade.php
@@ -47,4 +47,5 @@
                                          :no_tickets_msg="$group['no_tickets_msg']">
         </x-tickets.index.section.content>
     @endforeach
+    {{ $tickets->links() }}
 @endsection

--- a/tests/Unit/Actions/Ticket/GroupTicketsActionTest.php
+++ b/tests/Unit/Actions/Ticket/GroupTicketsActionTest.php
@@ -1,0 +1,105 @@
+<?php
+    declare( strict_types = 1 );
+
+    use App\Actions\Ticket\GroupTicketsAction;
+    use App\Models\Ticket;
+    use App\Models\User;
+
+    beforeEach( function () {
+        $this->action = new GroupTicketsAction();
+        $this->user = User::factory()->state( [ 'role' => 'agent' ] )->create();
+
+        $this->testConfig = [
+            [
+                'title' => 'In Progress',
+                'status' => [ 'in-progress' ],
+                'assignee_required' => true,
+                'no_tickets_msg' => 'No tickets in progress'
+            ],
+            [
+                'title' => 'Open',
+                'status' => [ 'open' ],
+                'assignee_required' => false,
+                'no_tickets_msg' => 'No open tickets'
+            ]
+        ];
+    } );
+
+    describe( 'GroupTicketsAction', function () {
+        it( 'should group tickets according to their status', function () {
+            $tickets = collect( [
+                Ticket::factory()
+                    ->inProgress()
+                    ->withAssignee( $this->user )
+                    ->withRequestor()
+                    ->create(),
+                Ticket::factory()
+                    ->open()
+                    ->withRequestor()
+                    ->create()
+            ] );
+
+            $result = $this->action->execute( $tickets, $this->testConfig, $this->user );
+
+            expect( $result )->toHaveCount( 2 )
+                ->and( $result[0]['tickets'] )->toHaveCount( 1 )
+                ->and( $result[1]['tickets'] )->toHaveCount( 1 );
+        } );
+
+        it( 'should return empty groups when no tickets are provided', function () {
+            $result = $this->action->execute( collect(), $this->testConfig, $this->user );
+
+            expect( $result )->toHaveCount( 2 )
+                ->and( $result[0]['tickets'] )->toBeEmpty()
+                ->and( $result[1]['tickets'] )->toBeEmpty();
+        } );
+
+        it( 'should filter tickets based on assignee when required', function () {
+            $otherUser = User::factory()->state( [ 'role' => 'agent' ] )->create();
+            $tickets = collect( [
+                Ticket::factory()
+                    ->inProgress()
+                    ->withAssignee( $this->user )
+                    ->withRequestor()
+                    ->create(),
+                Ticket::factory()
+                    ->inProgress()
+                    ->withAssignee( $otherUser )
+                    ->withRequestor()
+                    ->create()
+            ] );
+
+            $result = $this->action->execute( $tickets, $this->testConfig, $this->user );
+
+            expect( $result[0]['tickets'] )->toHaveCount( 1 )
+                ->and( $result[0]['tickets']->first()->assignee_id )->toBe( $this->user->id );
+        } );
+
+        it( 'should return fallback grouping when configuration is invalid', function () {
+            $tickets = collect( [
+                Ticket::factory()
+                    ->complete()
+                    ->create()
+            ] );
+            $invalidConfig = [ [ 'invalid' => 'config' ] ];
+
+            $result = $this->action->execute( $tickets, $invalidConfig, $this->user );
+
+            expect( $result )->toHaveCount( 1 )
+                ->and( $result[0]['title'] )->toBe( 'All Tickets' )
+                ->and( $result[0]['tickets'] )->toHaveCount( 1 );
+        } );
+
+        it( 'should handle null user gracefully when assignee filtering is required', function () {
+            $tickets = collect( [
+                Ticket::factory()
+                    ->inProgress()
+                    ->withRequestor()
+                    ->create()
+            ] );
+
+            $result = $this->action->execute( $tickets, $this->testConfig, null );
+
+            expect( $result[0]['tickets'] )->toBeEmpty();
+        } );
+    } );

--- a/tests/Unit/Config/TicketGroupingsTest.php
+++ b/tests/Unit/Config/TicketGroupingsTest.php
@@ -1,0 +1,32 @@
+<?php
+    declare( strict_types = 1 );
+
+    use App\Config\TicketGroupings;
+    use Illuminate\Support\Facades\Config;
+
+    describe( 'TicketGroupings', function () {
+        beforeEach( function () {
+            Config::set( 'tickets.groupings.index', [
+                [
+                    'title' => 'Test Group',
+                    'status' => [ 'test-status' ],
+                    'no_tickets_msg' => 'No tickets'
+                ]
+            ] );
+        } );
+
+        it( 'should load valid index groupings from configuration', function () {
+            $groupings = TicketGroupings::getIndexGroupings();
+
+            expect( $groupings )->toBeArray()
+                ->and( $groupings )->toHaveCount( 1 )
+                ->and( $groupings[0]['title'] )->toBe( 'Test Group' );
+        } );
+
+        it( 'should throw exception when configuration is missing', function () {
+            Config::set( 'tickets.groupings.index', null );
+
+            expect( fn() => TicketGroupings::getIndexGroupings() )
+                ->toThrow( RuntimeException::class );
+        } );
+    } );

--- a/tests/Unit/Validators/TicketGroupingsValidatorTest.php
+++ b/tests/Unit/Validators/TicketGroupingsValidatorTest.php
@@ -1,0 +1,49 @@
+<?php
+    declare( strict_types = 1 );
+
+    use App\Validators\TicketGroupingsValidator;
+
+    describe( 'TicketGroupingsValidator', function () {
+        it( 'should validate correct grouping configuration', function () {
+            $validConfig = [
+                [
+                    'title' => 'Test Group',
+                    'status' => [ 'open' ],
+                    'no_tickets_msg' => 'No tickets',
+                    'assignee_required' => true
+                ]
+            ];
+
+            expect( fn() => TicketGroupingsValidator::validate( $validConfig ) )
+                ->not->toThrow( RuntimeException::class );
+        } );
+
+        it( 'should reject configuration with missing required fields', function () {
+            $invalidConfig = [
+                [
+                    'title' => 'Test Group',
+                    // missing status and no_tickets_msg
+                ]
+            ];
+
+            expect( fn() => TicketGroupingsValidator::validate( $invalidConfig ) )
+                ->toThrow( RuntimeException::class );
+        } );
+
+        it( 'should validate all groups in configuration array', function () {
+            $mixedConfig = [
+                [
+                    'title' => 'Valid Group',
+                    'status' => [ 'open' ],
+                    'no_tickets_msg' => 'No tickets'
+                ],
+                [
+                    'title' => 'Invalid Group'
+                    // missing required fields
+                ]
+            ];
+
+            expect( fn() => TicketGroupingsValidator::validate( $mixedConfig ) )
+                ->toThrow( RuntimeException::class );
+        } );
+    } );


### PR DESCRIPTION
### Problem

* Closes #45 

The original issue identified several problems with ticket grouping implementation:
- Ticket grouping logic was embedded directly in Blade views, violating separation of concerns
- Complex filtering logic in views made maintenance difficult and testing impossible
- Configuration was hardcoded in views instead of being configurable

### Solution

Implemented a complete refactoring of the ticket grouping:

1. **GroupTicketsAction**: A dedicated action class that handles all ticket grouping logic
   - Implements flexible status-based grouping
   - Supports optional assignee filtering
   - Includes fallback behavior for error cases
   - Handles empty ticket collections gracefully

2. **Configuration Management**:
   - Added `tickets.php` config file for centralized grouping definitions
   - Created `TicketGroupings` class to provide type-safe access to configurations
   - Implemented configuration validation through `TicketGroupingsValidator`

3. **Enhanced Testing**:
   - Refactored `TicketFactory` to be more testable and independent
   - Added comprehensive test coverage for all new components
   - Improved factory state management for reliable test setup


### Testing

1. Unit Tests Added:
   - `GroupTicketsActionTest`: Tests for status grouping and assignee filtering
   - `TicketGroupingsTest`: Tests for config file loading and retrieval
   - `TicketGroupingsValidatorTest`: Tests for grouping schema validation

2. Test Coverage:
   - Status-based grouping functionality
   - Assignee filtering behavior
   - Empty collections handling
   - Error cases and fallback behavior
   - Configuration validation
   - Factory state management

3. Development Testing:
   - Tested locally with various ticket combinations
   - Verified pagination functionality
   - Checked error handling paths
   - Validated configuration loading
