### PR TITLE
[Enhancement] Configure production logging with daily rotation and cleanup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,4 +80,4 @@ jobs:
           PROD_UNSPLASH_RATE_LIMITING_ENABLED: ${{ secrets.PROD_UNSPLASH_RATE_LIMITING_ENABLED }}
           PROD_UNSPLASH_RATE_LIMITING_THRESHOLD: ${{ secrets.PROD_UNSPLASH_RATE_LIMITING_THRESHOLD }}
         run: |
-          ssh -o StrictHostKeyChecking=no $PROD_DEPLOY_USER@$PROD_DEPLOY_HOST "bash deploy.sh $GITHUB_SHA"
+          ssh -o StrictHostKeyChecking=no $PROD_DEPLOY_USER@$PROD_DEPLOY_HOST "bash -l deploy.sh $GITHUB_SHA"

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,132 +1,133 @@
 <?php
+    declare( strict_types = 1 );
 
-use Monolog\Handler\NullHandler;
-use Monolog\Handler\StreamHandler;
-use Monolog\Handler\SyslogUdpHandler;
-use Monolog\Processor\PsrLogMessageProcessor;
+    use Monolog\Handler\NullHandler;
+    use Monolog\Handler\StreamHandler;
+    use Monolog\Handler\SyslogUdpHandler;
+    use Monolog\Processor\PsrLogMessageProcessor;
 
-return [
+    return [
 
-    /*
-    |--------------------------------------------------------------------------
-    | Default Log Channel
-    |--------------------------------------------------------------------------
-    |
-    | This option defines the default log channel that is utilized to write
-    | messages to your logs. The value provided here should match one of
-    | the channels present in the list of "channels" configured below.
-    |
-    */
+        /*
+        |--------------------------------------------------------------------------
+        | Default Log Channel
+        |--------------------------------------------------------------------------
+        |
+        | This option defines the default log channel that is utilized to write
+        | messages to your logs. The value provided here should match one of
+        | the channels present in the list of "channels" configured below.
+        |
+        */
 
-    'default' => env('LOG_CHANNEL', 'stack'),
+        'default' => env( 'LOG_CHANNEL', 'stack' ),
 
-    /*
-    |--------------------------------------------------------------------------
-    | Deprecations Log Channel
-    |--------------------------------------------------------------------------
-    |
-    | This option controls the log channel that should be used to log warnings
-    | regarding deprecated PHP and library features. This allows you to get
-    | your application ready for upcoming major versions of dependencies.
-    |
-    */
+        /*
+        |--------------------------------------------------------------------------
+        | Deprecations Log Channel
+        |--------------------------------------------------------------------------
+        |
+        | This option controls the log channel that should be used to log warnings
+        | regarding deprecated PHP and library features. This allows you to get
+        | your application ready for upcoming major versions of dependencies.
+        |
+        */
 
-    'deprecations' => [
-        'channel' => env('LOG_DEPRECATIONS_CHANNEL', 'null'),
-        'trace' => env('LOG_DEPRECATIONS_TRACE', false),
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Log Channels
-    |--------------------------------------------------------------------------
-    |
-    | Here you may configure the log channels for your application. Laravel
-    | utilizes the Monolog PHP logging library, which includes a variety
-    | of powerful log handlers and formatters that you're free to use.
-    |
-    | Available drivers: "single", "daily", "slack", "syslog",
-    |                    "errorlog", "monolog", "custom", "stack"
-    |
-    */
-
-    'channels' => [
-
-        'stack' => [
-            'driver' => 'stack',
-            'channels' => explode(',', env('LOG_STACK', 'single')),
-            'ignore_exceptions' => false,
+        'deprecations' => [
+            'channel' => env( 'LOG_DEPRECATIONS_CHANNEL', 'null' ),
+            'trace' => env( 'LOG_DEPRECATIONS_TRACE', false ),
         ],
 
-        'single' => [
-            'driver' => 'single',
-            'path' => storage_path('logs/laravel.log'),
-            'level' => env('LOG_LEVEL', 'debug'),
-            'replace_placeholders' => true,
-        ],
+        /*
+        |--------------------------------------------------------------------------
+        | Log Channels
+        |--------------------------------------------------------------------------
+        |
+        | Here you may configure the log channels for your application. Laravel
+        | utilizes the Monolog PHP logging library, which includes a variety
+        | of powerful log handlers and formatters that you're free to use.
+        |
+        | Available drivers: "single", "daily", "slack", "syslog",
+        |                    "errorlog", "monolog", "custom", "stack"
+        |
+        */
 
-        'daily' => [
-            'driver' => 'daily',
-            'path' => storage_path('logs/laravel.log'),
-            'level' => env('LOG_LEVEL', 'debug'),
-            'days' => env('LOG_DAILY_DAYS', 14),
-            'replace_placeholders' => true,
-        ],
+        'channels' => [
 
-        'slack' => [
-            'driver' => 'slack',
-            'url' => env('LOG_SLACK_WEBHOOK_URL'),
-            'username' => env('LOG_SLACK_USERNAME', 'Laravel Log'),
-            'emoji' => env('LOG_SLACK_EMOJI', ':boom:'),
-            'level' => env('LOG_LEVEL', 'critical'),
-            'replace_placeholders' => true,
-        ],
-
-        'papertrail' => [
-            'driver' => 'monolog',
-            'level' => env('LOG_LEVEL', 'debug'),
-            'handler' => env('LOG_PAPERTRAIL_HANDLER', SyslogUdpHandler::class),
-            'handler_with' => [
-                'host' => env('PAPERTRAIL_URL'),
-                'port' => env('PAPERTRAIL_PORT'),
-                'connectionString' => 'tls://'.env('PAPERTRAIL_URL').':'.env('PAPERTRAIL_PORT'),
+            'stack' => [
+                'driver' => 'stack',
+                'channels' => [ 'daily', 'stderr' ],
+                'ignore_exceptions' => false,
             ],
-            'processors' => [PsrLogMessageProcessor::class],
-        ],
 
-        'stderr' => [
-            'driver' => 'monolog',
-            'level' => env('LOG_LEVEL', 'debug'),
-            'handler' => StreamHandler::class,
-            'formatter' => env('LOG_STDERR_FORMATTER'),
-            'with' => [
-                'stream' => 'php://stderr',
+            'single' => [
+                'driver' => 'single',
+                'path' => storage_path( 'logs/laravel.log' ),
+                'level' => env( 'LOG_LEVEL', 'debug' ),
+                'replace_placeholders' => true,
             ],
-            'processors' => [PsrLogMessageProcessor::class],
+
+            'daily' => [
+                'driver' => 'daily',
+                'path' => storage_path( 'logs/laravel.log' ),
+                'level' => env( 'LOG_LEVEL', 'error' ),
+                'days' => 30,
+                'replace_placeholders' => true,
+            ],
+
+            'slack' => [
+                'driver' => 'slack',
+                'url' => env( 'LOG_SLACK_WEBHOOK_URL' ),
+                'username' => env( 'LOG_SLACK_USERNAME', 'Laravel Log' ),
+                'emoji' => env( 'LOG_SLACK_EMOJI', ':boom:' ),
+                'level' => env( 'LOG_LEVEL', 'critical' ),
+                'replace_placeholders' => true,
+            ],
+
+            'papertrail' => [
+                'driver' => 'monolog',
+                'level' => env( 'LOG_LEVEL', 'debug' ),
+                'handler' => env( 'LOG_PAPERTRAIL_HANDLER', SyslogUdpHandler::class ),
+                'handler_with' => [
+                    'host' => env( 'PAPERTRAIL_URL' ),
+                    'port' => env( 'PAPERTRAIL_PORT' ),
+                    'connectionString' => 'tls://' . env( 'PAPERTRAIL_URL' ) . ':' . env( 'PAPERTRAIL_PORT' ),
+                ],
+                'processors' => [ PsrLogMessageProcessor::class ],
+            ],
+
+            'stderr' => [
+                'driver' => 'monolog',
+                'level' => env( 'LOG_LEVEL', 'error' ),
+                'handler' => StreamHandler::class,
+                'formatter' => env( 'LOG_STDERR_FORMATTER' ),
+                'with' => [
+                    'stream' => 'php://stderr',
+                ],
+                'processors' => [ PsrLogMessageProcessor::class ],
+            ],
+
+            'syslog' => [
+                'driver' => 'syslog',
+                'level' => env( 'LOG_LEVEL', 'debug' ),
+                'facility' => env( 'LOG_SYSLOG_FACILITY', LOG_USER ),
+                'replace_placeholders' => true,
+            ],
+
+            'errorlog' => [
+                'driver' => 'errorlog',
+                'level' => env( 'LOG_LEVEL', 'debug' ),
+                'replace_placeholders' => true,
+            ],
+
+            'null' => [
+                'driver' => 'monolog',
+                'handler' => NullHandler::class,
+            ],
+
+            'emergency' => [
+                'path' => storage_path( 'logs/laravel.log' ),
+            ],
+
         ],
 
-        'syslog' => [
-            'driver' => 'syslog',
-            'level' => env('LOG_LEVEL', 'debug'),
-            'facility' => env('LOG_SYSLOG_FACILITY', LOG_USER),
-            'replace_placeholders' => true,
-        ],
-
-        'errorlog' => [
-            'driver' => 'errorlog',
-            'level' => env('LOG_LEVEL', 'debug'),
-            'replace_placeholders' => true,
-        ],
-
-        'null' => [
-            'driver' => 'monolog',
-            'handler' => NullHandler::class,
-        ],
-
-        'emergency' => [
-            'path' => storage_path('logs/laravel.log'),
-        ],
-
-    ],
-
-];
+    ];


### PR DESCRIPTION
### Linked Issue
* Closes #60 

### Solution
Implemented proper production logging configuration with daily rotation and automatic cleanup:
- Configured daily log driver instead of single file
- Set 30-day retention period for logs
- Set production-appropriate log levels
